### PR TITLE
Refactor prompt by removing D3 logic instructions

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -20,11 +20,6 @@ export const FORMAT_INSTRUCTIONS: Record<EditFormat, string> = {
     "Delete all unused files, but we need to keep `README.md`. ",
     "Files can be deleted by setting their content to empty, for example:\n\n",
     "**fileToDelete.js**\n\n```\n```\n\n",
-    "For D3 logic, make sure it remains idempotent (use data joins), ",
-    "and prefer function signatures like `someFunction(selection, options)` ",
-    "where `selection` is a D3 selection and `options` is an object. ",
-    'Only import from the top-level `"d3"` module, not from submodules ',
-    '(e.g. imports from `"d3-scale"` or `"d3-shape"` are not supported).\n\n',
   ].join(""),
   diff: [
     "## Formatting Instructions\n\n",


### PR DESCRIPTION
Removed D3 logic guidelines from prompt, since it was causing problems where the LLM would add D3 unnecessarily in cases where D3 was not even being used originally.